### PR TITLE
Make LocalProgression soft dependency. + couple small changes

### DIFF
--- a/ExtraRundownCustomization/EntryPoint.cs
+++ b/ExtraRundownCustomization/EntryPoint.cs
@@ -8,7 +8,7 @@ using HarmonyLib;
 namespace ExtraRundownCustomization
 {
     [BepInDependency("com.dak.MTFO", BepInDependency.DependencyFlags.HardDependency)]
-    [BepInDependency("Inas.LocalProgression", BepInDependency.DependencyFlags.HardDependency)]
+    [BepInDependency("Inas.LocalProgression", BepInDependency.DependencyFlags.SoftDependency)]
     [BepInPlugin("RLC.ExtraRundownCustomization", "ExtraRundownCustomization", "1.0.0")]
     internal class EntryPoint : BasePlugin
     {

--- a/ExtraRundownCustomization/EntryPoint.cs
+++ b/ExtraRundownCustomization/EntryPoint.cs
@@ -9,7 +9,7 @@ namespace ExtraRundownCustomization
 {
     [BepInDependency("com.dak.MTFO", BepInDependency.DependencyFlags.HardDependency)]
     [BepInDependency("Inas.LocalProgression", BepInDependency.DependencyFlags.SoftDependency)]
-    [BepInPlugin("RLC.ExtraRundownCustomization", "ExtraRundownCustomization", "1.0.0")]
+    [BepInPlugin("RLC.ExtraRundownCustomization", "ExtraRundownCustomization", "1.0.1")]
     internal class EntryPoint : BasePlugin
     {
         private static Harmony _Harmony;

--- a/ExtraRundownCustomization/Handlers/RundownMenuHandlers.cs
+++ b/ExtraRundownCustomization/Handlers/RundownMenuHandlers.cs
@@ -9,6 +9,7 @@ using TMPro;
 using UnityEngine;
 using MTFO.API;
 using GTFO.API;
+using System.Linq;
 
 namespace ExtraRundownCustomization.Handlers
 {
@@ -391,39 +392,22 @@ namespace ExtraRundownCustomization.Handlers
                 }
             }
 
-            //Can't use a fucking switch :angry:
-            if (m_rundownInstance.m_currentRundownData.persistentID == m_activeGlobalRundownLayoutData.R1.RundownDatablockID)
-            {
-                UpdateRundown(m_activeGlobalRundownLayoutData.R1);
-            }
-            if (m_rundownInstance.m_currentRundownData.persistentID == m_activeGlobalRundownLayoutData.R2.RundownDatablockID)
-            {
-                UpdateRundown(m_activeGlobalRundownLayoutData.R2);
-            }
-            if (m_rundownInstance.m_currentRundownData.persistentID == m_activeGlobalRundownLayoutData.R3.RundownDatablockID)
-            {
-                UpdateRundown(m_activeGlobalRundownLayoutData.R3);
-            }
-            if (m_rundownInstance.m_currentRundownData.persistentID == m_activeGlobalRundownLayoutData.R4.RundownDatablockID)
-            {
-                UpdateRundown(m_activeGlobalRundownLayoutData.R4);
-            }
-            if (m_rundownInstance.m_currentRundownData.persistentID == m_activeGlobalRundownLayoutData.R5.RundownDatablockID)
-            {
-                UpdateRundown(m_activeGlobalRundownLayoutData.R5);
-            }
-            if (m_rundownInstance.m_currentRundownData.persistentID == m_activeGlobalRundownLayoutData.R6.RundownDatablockID)
-            {
-                UpdateRundown(m_activeGlobalRundownLayoutData.R6);
-            }
-            if (m_rundownInstance.m_currentRundownData.persistentID == m_activeGlobalRundownLayoutData.R7.RundownDatablockID)
-            {
-                UpdateRundown(m_activeGlobalRundownLayoutData.R7);
-            }
-            if (m_rundownInstance.m_currentRundownData.persistentID == m_activeGlobalRundownLayoutData.R8.RundownDatablockID)
-            {
-                UpdateRundown(m_activeGlobalRundownLayoutData.R8);
-            }
+            IndividualRundownLayout[] allRundownDatas = [
+                m_activeGlobalRundownLayoutData.R1,
+                m_activeGlobalRundownLayoutData.R2,
+                m_activeGlobalRundownLayoutData.R3,
+                m_activeGlobalRundownLayoutData.R4,
+                m_activeGlobalRundownLayoutData.R5,
+                m_activeGlobalRundownLayoutData.R6,
+                m_activeGlobalRundownLayoutData.R7,
+                m_activeGlobalRundownLayoutData.R8
+                ];
+            var correctRundown = allRundownDatas.FirstOrDefault(rundownData =>
+                rundownData.RundownDatablockID == m_rundownInstance.m_currentRundownData.persistentID
+            );
+
+            if (correctRundown != null)
+                UpdateRundown(correctRundown);
         }
 
         public static void UpdateMiscFeatures(bool isRepeat = false)

--- a/ExtraRundownCustomization/Handlers/RundownMenuHandlers.cs
+++ b/ExtraRundownCustomization/Handlers/RundownMenuHandlers.cs
@@ -215,6 +215,10 @@ namespace ExtraRundownCustomization.Handlers
                 expIcon.m_colorUnlocked = new UnityEngine.Color(data.buttonColor.r, data.buttonColor.g, data.buttonColor.b, data.buttonColor.a);
                 expIcon.m_colorStory = new UnityEngine.Color(data.buttonColor.r, data.buttonColor.g, data.buttonColor.b, data.buttonColor.a);
                 expIcon.m_colorLocked = new UnityEngine.Color(data.buttonColor.r, data.buttonColor.g, data.buttonColor.b, data.buttonColor.a * 0.66f);
+
+                // Set the hoverout alpha since the expedition icon gets reset frequently anyway
+                // the hoverout color change doesn't stay long and causes a small visual bug
+                expIcon.m_spriteAlphaOut = expIcon.m_spriteAlphaOver;
                 expIcon.SetBorderColor(new UnityEngine.Color(data.buttonColor.r, data.buttonColor.g, data.buttonColor.b, data.buttonColor.a));
                 expIcon.m_artifactHeatText.gameObject.SetActive(data.enableHeat);
                 expIcon.m_artifactHeatText.text = data.heatText;
@@ -277,7 +281,6 @@ namespace ExtraRundownCustomization.Handlers
                         sprite.color = BORDER_COLOR;
                     }
                 }
-                //Log.Info("Updated Icon");
             }
 
             void UpdateRundown(IndividualRundownLayout data)

--- a/ExtraRundownCustomization/Handlers/RundownMenuHandlers.cs
+++ b/ExtraRundownCustomization/Handlers/RundownMenuHandlers.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using TMPro;
 using UnityEngine;
 using MTFO.API;
+using GTFO.API;
 
 namespace ExtraRundownCustomization.Handlers
 {
@@ -230,6 +231,13 @@ namespace ExtraRundownCustomization.Handlers
                 expIcon.m_statusText.color = new UnityEngine.Color(1, 1, 1, 1);
                 index++;
 
+                InteropAPI.ExecuteWhenPluginExists("Inas.LocalProgression", (BepInEx.PluginInfo _) => DoLocalProgressionStuff(expIcon));
+
+                //Log.Info("Updated Icon");
+            }
+
+            void DoLocalProgressionStuff(CM_ExpeditionIcon_New expIcon)
+            {
                 //local prog bs starts here
                 var rundownID = LocalProgressionManager.Current.ActiveRundownID();
                 var lpData = LocalProgressionManager.Current.GetExpeditionLP(rundownID, expIcon.Tier, expIcon.ExpIndex);

--- a/ExtraRundownCustomization/Properties.props
+++ b/ExtraRundownCustomization/Properties.props
@@ -10,7 +10,7 @@
 		<PluginName>ExtraRundownCustomization</PluginName>
 		<RootNamespace>$(PluginName)</RootNamespace>
 		<AssemblyName>$(PluginName)</AssemblyName>
-		<Version>1.0.0</Version>
+		<Version>1.0.1</Version>
 		<CopyBuildToPluginFolder>true</CopyBuildToPluginFolder>
 	</PropertyGroup>
 


### PR DESCRIPTION
With GTFO-API's new update, soft dependencies are very simple to set up, you just put the code in another method and run it via `InteropAPI.ExecuteWhenPluginExists()`

One of the small changes included is a change to the icon's m_spriteAlphaOut, to match its m_spriteAlphaOver. these determine the alpha of the box when you hover over it, or stop hovering (hover out). Because of the every-second-or-two reupdating of the rundown icons, they'll update to being at the max hover color anyway, so just make the temporary change not happen. It could cause a slight color overlapping of the LocalProgression Omnipotent box in the small time frame.
<img width="267" height="129" alt="image" src="https://github.com/user-attachments/assets/eae15f41-9e62-413b-8735-b58e398e065b" />

The other small change is just a small refactor to the `if` tree that was angry it couldn't be a switch.