### PR TITLE
`show`, `textScale`, `color`, `enabled`, and `useFlatVersion`

### DIFF
--- a/ExtraRundownCustomization/DataHolders/Color.cs
+++ b/ExtraRundownCustomization/DataHolders/Color.cs
@@ -7,5 +7,6 @@
         public float g { get; set; }
         public float b { get; set; }
         public float a { get; set; }
+        public static implicit operator UnityEngine.Color (Color c) => new UnityEngine.Color() { r = c.r, g = c.g, b = c.b, a = c.a };
     }
 }

--- a/ExtraRundownCustomization/DataHolders/CustomRundownSelections.cs
+++ b/ExtraRundownCustomization/DataHolders/CustomRundownSelections.cs
@@ -118,6 +118,7 @@ namespace ExtraRundownCustomization.DataHolders
         public string name { get; set; }
         public virtual string altText { get; set; }
 
+        public bool useFlatVersion { get; set; } = false;
         public Vector3 pos { get; set; }
         public Vector3 rot { get; set; }
         public Vector3 scale { get; set; }

--- a/ExtraRundownCustomization/DataHolders/CustomRundownSelections.cs
+++ b/ExtraRundownCustomization/DataHolders/CustomRundownSelections.cs
@@ -16,7 +16,7 @@ namespace ExtraRundownCustomization.DataHolders
 
             pos = new() { x = -476.0f, y = 45.0f, z = 0.0f },
             rot = new() { x = 0.0f, y = 0.0f, z = 0.0f },
-            scale = new() { x = 0.6f, y = 0.6f, z = 0.6f },
+            scale = new() { x = 1.0f, y = 1.0f, z = 1.0f },
 
             namePos = new() { x = 0.0f, y = 39.0f, z = 0.0f },
             altTextPos = new() { x = -46.0f, y = 34.8f, z = 0.0f },
@@ -29,7 +29,7 @@ namespace ExtraRundownCustomization.DataHolders
 
             pos = new() { x = -241f, y = -78f, z = 0f },
             rot = new() { x = 0f, y = 0f, z = 0f },
-            scale = new() { x = 0.8f, y = 0.8f, z = 0.8f },
+            scale = new() { x = 1.0f, y = 1.0f, z = 1.0f },
 
             namePos = new() { x = 0f, y = 39f, z = 0f },
             altTextPos = new() { x = -46f, y = 34.8f, z = 0f }
@@ -42,7 +42,7 @@ namespace ExtraRundownCustomization.DataHolders
 
             pos = new() { x = -346f, y = 179.6f, z = 13.956f },
             rot = new() { x = 0f, y = 0f, z = 0f },
-            scale = new() { x = 0.8f, y = 0.8f, z = 0.8f },
+            scale = new() { x = 1.0f, y = 1.0f, z = 1.0f },
 
             namePos = new() { x = 0f, y = 39f, z = 0f },
             altTextPos = new() { x = -46f, y = 34.8f, z = 0f }
@@ -55,7 +55,7 @@ namespace ExtraRundownCustomization.DataHolders
 
             pos = new() { x = -109f, y = 226f, z = 0f },
             rot = new() { x = 0f, y = 0f, z = 0f },
-            scale = new() { x = 1.2f, y = 1.2f, z = 1.2f },
+            scale = new() { x = 1.0f, y = 1.0f, z = 1.0f },
 
             namePos = new() { x = 0f, y = 39f, z = 0f },
             altTextPos = new() { x = -46f, y = 34.8f, z = 0f }
@@ -68,7 +68,7 @@ namespace ExtraRundownCustomization.DataHolders
 
             pos = new() { x = 55f, y = -16f, z = 0f },
             rot = new() { x = 0f, y = 0f, z = 0f },
-            scale = new() { x = 1.1f, y = 1.1f, z = 1.1f },
+            scale = new() { x = 1.0f, y = 1.0f, z = 1.0f },
 
             namePos = new() { x = 0f, y = 39f, z = 0f },
             altTextPos = new() { x = -46f, y = 34.8f, z = 0f }
@@ -81,7 +81,7 @@ namespace ExtraRundownCustomization.DataHolders
 
             pos = new() { x = 240f, y = 235f, z = 0f },
             rot = new() { x = 0f, y = 0f, z = 0f },
-            scale = new() { x = 1.09f, y = 1.09f, z = 1.09f },
+            scale = new() { x = 1.0f, y = 1.0f, z = 1.0f },
 
             namePos = new() { x = 0f, y = 39f, z = 0f },
             altTextPos = new() { x = -46f, y = 34.8f, z = 0f }
@@ -90,11 +90,11 @@ namespace ExtraRundownCustomization.DataHolders
         public RundownSelector Selector_R7 { get; set; } = new RundownSelector
         {
             name = "R7",
-            altText = "<color=orange>ALT://",
+            altText = "",
 
             pos = new() { x = 317f, y = -104f, z = 0f },
             rot = new() { x = 0f, y = 0f, z = 0f },
-            scale = new() { x = 1f, y = 1f, z = 1f },
+            scale = new() { x = 1.0f, y = 1.0f, z = 1.0f },
 
             namePos = new() { x = 0f, y = 39f, z = 0f },
             altTextPos = new() { x = -46f, y = 34.8f, z = 0f }
@@ -105,9 +105,9 @@ namespace ExtraRundownCustomization.DataHolders
 
             pos = new() { x = 550.0f, y = 150.0f, z = 0.0f },
             rot = new() { x = 0.0f, y = 0.0f, z = 0.0f },
-            scale = new() { x = 1.25f, y = 1.2f, z = 1.25f },
+            scale = new() { x = 1.0f, y = 1.0f, z = 1.0f },
 
-            namePos = new() { x = 0f, y = 39f, z = 0.0f }
+            namePos = new() { x = 0f, y = 134f, z = 0.0f }
         };
     }
 
@@ -123,7 +123,8 @@ namespace ExtraRundownCustomization.DataHolders
 
         public Vector3 namePos { get; set; }
         public virtual Vector3 altTextPos { get; set; }
-        public Vector3 textScale { get; set; } = new() { x=1, y=1, z=1 };
+        public Vector3 textScale { get; set; } = new() { x = 1, y = 1, z = 1 };
+        public Color color { get; set; } = new() { r = 1, g = 1, b = 1, a = 0.7843f };
     }
     public class RundownSelector_R8 : RundownSelector
     {

--- a/ExtraRundownCustomization/DataHolders/CustomRundownSelections.cs
+++ b/ExtraRundownCustomization/DataHolders/CustomRundownSelections.cs
@@ -102,6 +102,7 @@
 
     public class RundownSelector
     {
+        public bool enabled { get; set; } = true; // default value for backcompat
         public string name { get; set; }
         public string altText { get; set; }
 
@@ -111,9 +112,11 @@
 
         public Vector3 namePos { get; set; }
         public Vector3 altTextPos { get; set; }
+        public Vector3 textScale { get; set; } = new() { x=1, y=1, z=1 };
     }
     public class Selection_R8
     {
+        public bool enabled { get; set; } = true; // default value for backcompat
         public string name { get; set; } = "R8";
 
         public Vector3 pos { set; get; } = new() { x = 550.0f, y = 150.0f, z = 0.0f };
@@ -121,5 +124,22 @@
         public Vector3 scale { get; set; } = new() { x = 1.25f, y = 1.2f, z = 1.25f};
 
         public Vector3 namePos { get; set; } = new() { x = 0f, y = 39f, z = 0.0f };
+        public Vector3 textScale { get; set; } = new() { x = 1, y = 1, z = 1 };
+
+        // implicitly be able to cast this to save on some code later
+        // Gotta be careful for if any values get added to either of these, gotta make sure it gets added to the other as well
+        public static implicit operator RundownSelector(Selection_R8 selection)
+        {
+            return new()
+            {
+                enabled = selection.enabled,
+                name = selection.name,
+                pos = selection.pos,
+                rot = selection.rot,
+                scale = selection.scale,
+                namePos = selection.namePos,
+                textScale = selection.textScale,
+            };
+        }
     }
 }

--- a/ExtraRundownCustomization/DataHolders/CustomRundownSelections.cs
+++ b/ExtraRundownCustomization/DataHolders/CustomRundownSelections.cs
@@ -1,4 +1,6 @@
-﻿namespace ExtraRundownCustomization.DataHolders
+﻿using System.Text.Json.Serialization;
+
+namespace ExtraRundownCustomization.DataHolders
 {
     [System.Serializable]
     public class CustomRundownSelections
@@ -97,49 +99,37 @@
             namePos = new() { x = 0f, y = 39f, z = 0f },
             altTextPos = new() { x = -46f, y = 34.8f, z = 0f }
         };
-        public Selection_R8 Selector_R8 { get; set; } = new();
+        public RundownSelector_R8 Selector_R8 { get; set; } = new RundownSelector_R8
+        {
+            name = "R8",
+
+            pos = new() { x = 550.0f, y = 150.0f, z = 0.0f },
+            rot = new() { x = 0.0f, y = 0.0f, z = 0.0f },
+            scale = new() { x = 1.25f, y = 1.2f, z = 1.25f },
+
+            namePos = new() { x = 0f, y = 39f, z = 0.0f }
+        };
     }
 
     public class RundownSelector
     {
         public bool enabled { get; set; } = true; // default value for backcompat
         public string name { get; set; }
-        public string altText { get; set; }
+        public virtual string altText { get; set; }
 
         public Vector3 pos { get; set; }
         public Vector3 rot { get; set; }
         public Vector3 scale { get; set; }
 
         public Vector3 namePos { get; set; }
-        public Vector3 altTextPos { get; set; }
+        public virtual Vector3 altTextPos { get; set; }
         public Vector3 textScale { get; set; } = new() { x=1, y=1, z=1 };
     }
-    public class Selection_R8
+    public class RundownSelector_R8 : RundownSelector
     {
-        public bool enabled { get; set; } = true; // default value for backcompat
-        public string name { get; set; } = "R8";
-
-        public Vector3 pos { set; get; } = new() { x = 550.0f, y = 150.0f, z = 0.0f };
-        public Vector3 rot { set; get; } = new() { x = 0.0f, y = 0.0f, z = 0.0f };
-        public Vector3 scale { get; set; } = new() { x = 1.25f, y = 1.2f, z = 1.25f};
-
-        public Vector3 namePos { get; set; } = new() { x = 0f, y = 39f, z = 0.0f };
-        public Vector3 textScale { get; set; } = new() { x = 1, y = 1, z = 1 };
-
-        // implicitly be able to cast this to save on some code later
-        // Gotta be careful for if any values get added to either of these, gotta make sure it gets added to the other as well
-        public static implicit operator RundownSelector(Selection_R8 selection)
-        {
-            return new()
-            {
-                enabled = selection.enabled,
-                name = selection.name,
-                pos = selection.pos,
-                rot = selection.rot,
-                scale = selection.scale,
-                namePos = selection.namePos,
-                textScale = selection.textScale,
-            };
-        }
+        [JsonIgnore]
+        public override string altText { get; set; }
+        [JsonIgnore]
+        public override Vector3 altTextPos { get; set; }
     }
 }

--- a/ExtraRundownCustomization/DataHolders/CustomRundownSelections.cs
+++ b/ExtraRundownCustomization/DataHolders/CustomRundownSelections.cs
@@ -113,7 +113,7 @@ namespace ExtraRundownCustomization.DataHolders
 
     public class RundownSelector
     {
-        public bool enabled { get; set; } = true; // default value for backcompat
+        public bool show { get; set; } = true; // default value for backcompat
         public string name { get; set; }
         public virtual string altText { get; set; }
 

--- a/ExtraRundownCustomization/DataHolders/CustomRundownSelections.cs
+++ b/ExtraRundownCustomization/DataHolders/CustomRundownSelections.cs
@@ -114,6 +114,7 @@ namespace ExtraRundownCustomization.DataHolders
     public class RundownSelector
     {
         public bool show { get; set; } = true; // default value for backcompat
+        public bool enabled { get; set; } = true;
         public string name { get; set; }
         public virtual string altText { get; set; }
 

--- a/ExtraRundownCustomization/DataHolders/Vector3.cs
+++ b/ExtraRundownCustomization/DataHolders/Vector3.cs
@@ -6,5 +6,6 @@
         public float x { get; set; }
         public float y { get; set; }
         public float z { get; set; }
+        public static implicit operator UnityEngine.Vector3(Vector3 v) => new UnityEngine.Vector3(v.x, v.y, v.z);
     }
 }

--- a/ExtraRundownCustomization/Handlers/RundownMenuHandlers.cs
+++ b/ExtraRundownCustomization/Handlers/RundownMenuHandlers.cs
@@ -158,12 +158,19 @@ namespace ExtraRundownCustomization.Handlers
                 // inverse the text's rotation so it doesn't look weird
                 comp.m_rundownText.transform.parent.localRotation = Quaternion.Inverse(comp.transform.localRotation);
 
-                // Enable all objects that should be enabled (i.e they already were)
-                for (int i = 0; i < comp.transform.GetChildCount(); i++)
-                {
-                    GameObject obj = comp.transform.GetChild(i).gameObject;
-                    obj.SetActive(data.enabled);
-                }
+                comp.m_originalColor = data.color;
+                // Calling these functions are what will actually update the color
+                if (comp.m_isHovering)
+                    comp.OnHoverIn();
+                else
+                    comp.OnHoverOut();
+
+                    // Enable all objects that should be enabled (i.e they already were)
+                    for (int i = 0; i < comp.transform.GetChildCount(); i++)
+                    {
+                        GameObject obj = comp.transform.GetChild(i).gameObject;
+                        obj.SetActive(data.enabled);
+                    }
                 // remove collider so you can't still enter the screen if you click the right spot lol
                 comp.m_collider.enabled = data.enabled;
             }

--- a/ExtraRundownCustomization/Handlers/RundownMenuHandlers.cs
+++ b/ExtraRundownCustomization/Handlers/RundownMenuHandlers.cs
@@ -165,14 +165,18 @@ namespace ExtraRundownCustomization.Handlers
                 else
                     comp.OnHoverOut(); // OnHoverOut is used for future proofing for liveedit
 
-                    // Enable all objects that should be enabled (i.e they already were)
+                if (data.useFlatVersion)
+                    comp.RotateGUIXFlat();
+                else
+                    comp.ResetGUIXRotation(); // pretty much for hotreload purposes
+
                 comp.SetIsUsed(data.enabled);
 
-                    for (int i = 0; i < comp.transform.GetChildCount(); i++)
-                    {
-                        GameObject obj = comp.transform.GetChild(i).gameObject;
+                for (int i = 0; i < comp.transform.GetChildCount(); i++)
+                {
+                    GameObject obj = comp.transform.GetChild(i).gameObject;
                     obj.SetActive(data.show);
-                    }
+                }
                 // remove collider so you can't still enter the screen if you click the right spot lol
                 comp.m_collider.enabled = data.show;
             }

--- a/ExtraRundownCustomization/Handlers/RundownMenuHandlers.cs
+++ b/ExtraRundownCustomization/Handlers/RundownMenuHandlers.cs
@@ -110,9 +110,9 @@ namespace ExtraRundownCustomization.Handlers
 
             void UpdateRundownSelector(CM_RundownSelection comp, RundownSelector data)
             {
-                comp.transform.localPosition = new UnityEngine.Vector3(data.pos.x, data.pos.y, data.pos.z);
-                comp.transform.localRotation = Quaternion.Euler(new UnityEngine.Vector3(data.rot.x, data.rot.y, data.rot.z));
-                comp.transform.localScale = new UnityEngine.Vector3(data.scale.x, data.scale.y, data.scale.z);
+                comp.transform.localPosition = data.pos;
+                comp.transform.localRotation = Quaternion.Euler(data.rot);
+                comp.transform.localScale = data.scale;
 
                 // R7 and R8 are special cases, R7 has the text component but it's not assigned, and R8 doesn't have it at all
                 if (comp.transform.GetChildCount() < 3) // only R8 has 3 children because of this situation
@@ -123,14 +123,15 @@ namespace ExtraRundownCustomization.Handlers
                         comp.m_altText.gameObject.SetActive(true);
                     }
                     comp.m_altText.text = data.altText;
-                    comp.m_altText.transform.localPosition = new UnityEngine.Vector3(data.altTextPos.x, data.altTextPos.y, data.altTextPos.z);
+                    comp.m_altText.transform.localPosition = data.altTextPos;
                 }
                 else // if was R8, then all of this^ would pass by
                 {
                     /* To keep everything hidden properly and forever, we can't just deactivate the game object, as reentering the selector screen would show them again
                     *  Normally everything's fine, because everything that would stay shown is under sub objects
                     *  The one exception is the R8 Friends Hosting text, which if it somehow decided to show, would bypass the game objects being deactivated
-                    * so if its holder is still present, parent it to another sub object   */
+                    *  so if its holder is still present, parent it to another sub object 
+                    *  this doesn't break component references, so things still update fine  */
                     var friendGO = comp.transform.Find("FriendsHosting");
                     if (friendGO != null) // hasn't already been moved
                     {
@@ -153,7 +154,7 @@ namespace ExtraRundownCustomization.Handlers
                 }
                 
                 comp.m_rundownText.text = data.name;
-                comp.m_rundownText.transform.localPosition = new UnityEngine.Vector3(data.namePos.x, data.namePos.y, data.namePos.z);
+                comp.m_rundownText.transform.localPosition = data.namePos;
 
                 // Enable all objects that should be enabled (i.e they already were)
                 for (int i = 0; i < comp.transform.GetChildCount(); i++)
@@ -192,24 +193,24 @@ namespace ExtraRundownCustomization.Handlers
                     return;
                 }
                 expIcon.SetShortName("<color=white>" + data.label);
-                expIcon.transform.localPosition = new UnityEngine.Vector3(data.buttonPos.x, data.buttonPos.y, data.buttonPos.z);
+                expIcon.transform.localPosition = data.buttonPos;
                 if (data.changeScale)
                 {
-                    expIcon.transform.localScale = new UnityEngine.Vector3(data.buttonScale.x, data.buttonScale.y, data.buttonScale.z);
+                    expIcon.transform.localScale = data.buttonScale;
                 }
                 //Since local prog sets the colour earlier I'm free to override it here
                 //And yes my dumbass put it in the wrong thing i woke up 20 minutes ago okay
-                expIcon.m_colorUnlocked = new UnityEngine.Color(data.buttonColor.r, data.buttonColor.g, data.buttonColor.b, data.buttonColor.a);
-                expIcon.m_colorStory = new UnityEngine.Color(data.buttonColor.r, data.buttonColor.g, data.buttonColor.b, data.buttonColor.a);
-                expIcon.m_colorLocked = new UnityEngine.Color(data.buttonColor.r, data.buttonColor.g, data.buttonColor.b, data.buttonColor.a * 0.66f);
+                expIcon.m_colorUnlocked = data.buttonColor;
+                expIcon.m_colorStory = data.buttonColor;
+                expIcon.m_colorLocked = data.buttonColor;
 
                 // Set the hoverout alpha since the expedition icon gets reset frequently anyway
                 // the hoverout color change doesn't stay long and causes a small visual bug
                 expIcon.m_spriteAlphaOut = expIcon.m_spriteAlphaOver;
-                expIcon.SetBorderColor(new UnityEngine.Color(data.buttonColor.r, data.buttonColor.g, data.buttonColor.b, data.buttonColor.a));
+                expIcon.SetBorderColor(data.buttonColor);
                 expIcon.m_artifactHeatText.gameObject.SetActive(data.enableHeat);
                 expIcon.m_artifactHeatText.text = data.heatText;
-                expIcon.m_statusText.transform.localPosition = new UnityEngine.Vector3(data.statusPos.x, data.statusPos.y, data.statusPos.z);
+                expIcon.m_statusText.transform.localPosition = data.statusPos;
                 if (data.overrideDecryptText)
                 {
                     expIcon.m_decryptErrorText.gameObject.SetActive(true);
@@ -372,7 +373,7 @@ namespace ExtraRundownCustomization.Handlers
                 {
                     GameObject extPage = m_rundownInstance.m_guix_Ext.gameObject;
                     extPage.SetActive(data.EnableExtensionPage);
-                    extPage.transform.localPosition = new UnityEngine.Vector3(data.ExtensionPagePos.x, data.ExtensionPagePos.y, data.ExtensionPagePos.z);
+                    extPage.transform.localPosition = data.ExtensionPagePos;
                     extPage.transform.localScale = new UnityEngine.Vector3(0.85f, 0.85f, 0.85f);
                     m_rundownInstance.m_externalExpHeader.text = data.ExtensionPageText;
                 }
@@ -456,7 +457,7 @@ namespace ExtraRundownCustomization.Handlers
                 {
                     goto suddenDeath;
                 }
-                m_rundownInstance.m_tierMarkerSectorSummary.transform.localPosition = new UnityEngine.Vector3(m_activeMiscRundownData.SectorSummaryPosition.x, m_activeMiscRundownData.SectorSummaryPosition.y, m_activeMiscRundownData.SectorSummaryPosition.z);
+                m_rundownInstance.m_tierMarkerSectorSummary.transform.localPosition = m_activeMiscRundownData.SectorSummaryPosition;
                 m_rundownInstance.m_tierMarkerSectorSummary.transform.GetChild(0).GetChild(0).gameObject.SetActive(false);
             }
             suddenDeath:
@@ -530,7 +531,7 @@ namespace ExtraRundownCustomization.Handlers
 
                 m_rundownInstance.transform.GetChild(2).GetChild(4).GetChild(18).gameObject.SetActive(false);
                 m_rundownInstance.m_rundownIntelButton.gameObject.SetActive(m_activeMiscRundownData.EnableIntelButton);
-                m_rundownInstance.m_rundownIntelButton.transform.localPosition = new UnityEngine.Vector3(m_activeMiscRundownData.IntelButtonPosition.x, m_activeMiscRundownData.IntelButtonPosition.y, m_activeMiscRundownData.IntelButtonPosition.z);
+                m_rundownInstance.m_rundownIntelButton.transform.localPosition = m_activeMiscRundownData.IntelButtonPosition;
                 //Log.Info("Overridden intel button");
             }
 

--- a/ExtraRundownCustomization/Handlers/RundownMenuHandlers.cs
+++ b/ExtraRundownCustomization/Handlers/RundownMenuHandlers.cs
@@ -149,12 +149,14 @@ namespace ExtraRundownCustomization.Handlers
                         textHolder.SetParent(comp.transform, worldPositionStays: false);
                         textGO.SetParent(textHolder, worldPositionStays: true);
                     }
-
-                    
                 }
                 
                 comp.m_rundownText.text = data.name;
                 comp.m_rundownText.transform.localPosition = data.namePos;
+                // scale the text parent so it applies to the alt and rundown text equally
+                comp.m_rundownText.transform.parent.localScale = data.textScale;
+                // inverse the text's rotation so it doesn't look weird
+                comp.m_rundownText.transform.parent.localRotation = Quaternion.Inverse(comp.transform.localRotation);
 
                 // Enable all objects that should be enabled (i.e they already were)
                 for (int i = 0; i < comp.transform.GetChildCount(); i++)

--- a/ExtraRundownCustomization/Handlers/RundownMenuHandlers.cs
+++ b/ExtraRundownCustomization/Handlers/RundownMenuHandlers.cs
@@ -166,6 +166,8 @@ namespace ExtraRundownCustomization.Handlers
                     comp.OnHoverOut(); // OnHoverOut is used for future proofing for liveedit
 
                     // Enable all objects that should be enabled (i.e they already were)
+                comp.SetIsUsed(data.enabled);
+
                     for (int i = 0; i < comp.transform.GetChildCount(); i++)
                     {
                         GameObject obj = comp.transform.GetChild(i).gameObject;

--- a/ExtraRundownCustomization/Handlers/RundownMenuHandlers.cs
+++ b/ExtraRundownCustomization/Handlers/RundownMenuHandlers.cs
@@ -72,13 +72,6 @@ namespace ExtraRundownCustomization.Handlers
 
             UpdateMiscFeatures();
 
-            rundownSelectors.Clear();
-            for (int i = 0; i < 8; i++)
-            {
-                rundownSelectors.Add(__instance.m_rundownHolder.GetChild(16).GetChild(i).gameObject);
-                //Log.Info("Adding GO to the list GO name: " + __instance.m_rundownHolder.GetChild(16).GetChild(i).gameObject.name);
-            }
-
             if (m_rundownInstance.m_currentRundownData != null)
             {
                 __instance.m_textRundownHeaderTop.text = "<color=white><size=300%>" + m_rundownInstance.m_currentRundownData.StorytellingData.Title;
@@ -93,90 +86,83 @@ namespace ExtraRundownCustomization.Handlers
                 __instance.m_textRundownHeader.text = m_rundownInstance.m_currentRundownData.StorytellingData.Title;
             }
 
-            foreach (GameObject obj in rundownSelectors)
+            // CM_PageRundown_New.m_rundownSelections is in the same order they're reveleaed in (1, 7, 2... 6, 8)
+            // so order the active selections accordingly
+            RundownSelector[] activeRundownSelections = [
+                m_activeRundownSelectionData.Selector_R1,
+                m_activeRundownSelectionData.Selector_R7,
+                m_activeRundownSelectionData.Selector_R2,
+                m_activeRundownSelectionData.Selector_R3,
+                m_activeRundownSelectionData.Selector_R4,
+                m_activeRundownSelectionData.Selector_R5,
+                m_activeRundownSelectionData.Selector_R6,
+                m_activeRundownSelectionData.Selector_R8,
+            ];
+
+            for (int i = 0; i < __instance.m_rundownSelections.Count; i++)
             {
-                //Log.Info("in foreach loop go name: " + obj.name);
-                switch (obj.name)
-                {
-                    case "Rundown_Surface_SelectionALT_R1":
-                    {
-                        UpdateRundownSelector(obj, m_activeRundownSelectionData.Selector_R1);
-                    }
-                    break;
+                CM_RundownSelection selector = __instance.m_rundownSelections[i];
+                RundownSelector selector_data = activeRundownSelections[i];
+                
+                UpdateRundownSelector(selector, selector_data);
 
-                    case "Rundown_Surface_SelectionALT_R2":
-                    {
-                        UpdateRundownSelector(obj, m_activeRundownSelectionData.Selector_R2);
-                    }
-                    break;
-
-                    case "Rundown_Surface_SelectionALT_R3":
-                    {
-                        UpdateRundownSelector(obj, m_activeRundownSelectionData.Selector_R3);
-                    }
-                    break;
-
-                    case "Rundown_Surface_SelectionALT_R4":
-                    {
-                        UpdateRundownSelector(obj, m_activeRundownSelectionData.Selector_R4);
-                    }
-                    break;
-
-                    case "Rundown_Surface_SelectionALT_R5":
-                    {
-                        UpdateRundownSelector(obj, m_activeRundownSelectionData.Selector_R5);
-                    }
-                    break;
-
-                    case "Rundown_Surface_SelectionALT_R6":
-                    {
-                        UpdateRundownSelector(obj, m_activeRundownSelectionData.Selector_R6);
-                    }
-                    break;
-
-                    case "Rundown_Surface_SelectionALT_R7":
-                    {
-
-                        obj.transform.localPosition = new UnityEngine.Vector3(m_activeRundownSelectionData.Selector_R7.pos.x, m_activeRundownSelectionData.Selector_R7.pos.y, m_activeRundownSelectionData.Selector_R7.pos.z);
-                        obj.transform.localRotation = Quaternion.Euler(new UnityEngine.Vector3(m_activeRundownSelectionData.Selector_R7.rot.x, m_activeRundownSelectionData.Selector_R7.rot.y, m_activeRundownSelectionData.Selector_R7.rot.z));
-                        obj.transform.localScale = new UnityEngine.Vector3(m_activeRundownSelectionData.Selector_R7.scale.x, m_activeRundownSelectionData.Selector_R7.scale.y, m_activeRundownSelectionData.Selector_R7.scale.z);
-
-                        var comp = obj.GetComponent<CM_RundownSelection>();
-                        TextMeshPro altText = obj.transform.GetChild(0).GetChild(0).GetComponent<TextMeshPro>();
-                        comp.m_rundownText.text = m_activeRundownSelectionData.Selector_R7.name;
-                        altText.text = m_activeRundownSelectionData.Selector_R7.altText;
-                        comp.m_rundownText.transform.localPosition = new UnityEngine.Vector3(m_activeRundownSelectionData.Selector_R7.namePos.x, m_activeRundownSelectionData.Selector_R7.namePos.y, m_activeRundownSelectionData.Selector_R7.namePos.z);
-                        altText.transform.localPosition = new UnityEngine.Vector3(m_activeRundownSelectionData.Selector_R7.altTextPos.x, m_activeRundownSelectionData.Selector_R7.altTextPos.y, m_activeRundownSelectionData.Selector_R7.altTextPos.z);
-                        altText.gameObject.SetActive(true);
-                    }
-                    break;
-
-                    case "Rundown_Surface_SelectionALT_R8":
-                    {
-
-                        obj.transform.localPosition = new UnityEngine.Vector3(m_activeRundownSelectionData.Selector_R8.pos.x, m_activeRundownSelectionData.Selector_R8.pos.y, m_activeRundownSelectionData.Selector_R8.pos.z);
-                        obj.transform.localRotation = Quaternion.Euler(new UnityEngine.Vector3(m_activeRundownSelectionData.Selector_R8.rot.x, m_activeRundownSelectionData.Selector_R8.rot.y, m_activeRundownSelectionData.Selector_R8.rot.z));
-                        obj.transform.localScale = new UnityEngine.Vector3(m_activeRundownSelectionData.Selector_R8.scale.x, m_activeRundownSelectionData.Selector_R8.scale.y, m_activeRundownSelectionData.Selector_R8.scale.z);
-
-                        var comp = obj.GetComponent<CM_RundownSelection>();
-                        comp.m_rundownText.text = m_activeRundownSelectionData.Selector_R8.name;
-                        comp.m_rundownText.transform.localPosition = new UnityEngine.Vector3(m_activeRundownSelectionData.Selector_R8.namePos.x, m_activeRundownSelectionData.Selector_R8.namePos.y, m_activeRundownSelectionData.Selector_R8.namePos.z);
-                    }
-                    break;
-                }
             }
 
-            void UpdateRundownSelector(GameObject obj, RundownSelector data)
+            void UpdateRundownSelector(CM_RundownSelection comp, RundownSelector data)
             {
-                obj.transform.localPosition = new UnityEngine.Vector3(data.pos.x, data.pos.y, data.pos.z);
-                obj.transform.localRotation = Quaternion.Euler(new UnityEngine.Vector3(data.rot.x, data.rot.y, data.rot.z));
-                obj.transform.localScale = new UnityEngine.Vector3(data.scale.x, data.scale.y, data.scale.z);
+                comp.transform.localPosition = new UnityEngine.Vector3(data.pos.x, data.pos.y, data.pos.z);
+                comp.transform.localRotation = Quaternion.Euler(new UnityEngine.Vector3(data.rot.x, data.rot.y, data.rot.z));
+                comp.transform.localScale = new UnityEngine.Vector3(data.scale.x, data.scale.y, data.scale.z);
 
-                var comp = obj.GetComponent<CM_RundownSelection>();
+                // R7 and R8 are special cases, R7 has the text component but it's not assigned, and R8 doesn't have it at all
+                if (comp.transform.GetChildCount() < 3) // only R8 has 3 children because of this situation
+                {
+                    if (comp.m_altText == null) // Object structure suggests that it has alt text tmp, but not assigned
+                    {
+                        comp.m_altText = comp.transform.GetChild(0).GetChild(0).GetComponent<TextMeshPro>();
+                        comp.m_altText.gameObject.SetActive(true);
+                    }
+                    comp.m_altText.text = data.altText;
+                    comp.m_altText.transform.localPosition = new UnityEngine.Vector3(data.altTextPos.x, data.altTextPos.y, data.altTextPos.z);
+                }
+                else // if was R8, then all of this^ would pass by
+                {
+                    /* To keep everything hidden properly and forever, we can't just deactivate the game object, as reentering the selector screen would show them again
+                    *  Normally everything's fine, because everything that would stay shown is under sub objects
+                    *  The one exception is the R8 Friends Hosting text, which if it somehow decided to show, would bypass the game objects being deactivated
+                    * so if its holder is still present, parent it to another sub object   */
+                    var friendGO = comp.transform.Find("FriendsHosting");
+                    if (friendGO != null) // hasn't already been moved
+                    {
+                        Transform friendHolder = new GameObject("TextHolder").transform;
+                        friendHolder.SetParent(comp.transform, worldPositionStays: false);
+                        friendGO.SetParent(friendHolder, worldPositionStays: true);
+
+
+                        /* repeat this whole process for the rundown text as well
+                        *  don't want to use the SAME holder because then child count will change for the above alt text logic
+                        *  also using the same if block because the idea is just to have done this exactly once
+                        *  so don't run the extra transform.Find() and null check */
+                        var textGO = comp.transform.Find("RundownText");
+                        Transform textHolder = new GameObject("TextHolder").transform;
+                        textHolder.SetParent(comp.transform, worldPositionStays: false);
+                        textGO.SetParent(textHolder, worldPositionStays: true);
+                    }
+
+                    
+                }
+                
                 comp.m_rundownText.text = data.name;
-                comp.m_altText.text = data.altText;
                 comp.m_rundownText.transform.localPosition = new UnityEngine.Vector3(data.namePos.x, data.namePos.y, data.namePos.z);
-                comp.m_altText.transform.localPosition = new UnityEngine.Vector3(data.altTextPos.x, data.altTextPos.y, data.altTextPos.z);
+
+                // Enable all objects that should be enabled (i.e they already were)
+                for (int i = 0; i < comp.transform.GetChildCount(); i++)
+                {
+                    GameObject obj = comp.transform.GetChild(i).gameObject;
+                    obj.SetActive(data.enabled);
+                }
+                // remove collider so you can't still enter the screen if you click the right spot lol
+                comp.m_collider.enabled = data.enabled;
             }
         }
 

--- a/ExtraRundownCustomization/Handlers/RundownMenuHandlers.cs
+++ b/ExtraRundownCustomization/Handlers/RundownMenuHandlers.cs
@@ -163,16 +163,16 @@ namespace ExtraRundownCustomization.Handlers
                 if (comp.m_isHovering)
                     comp.OnHoverIn();
                 else
-                    comp.OnHoverOut();
+                    comp.OnHoverOut(); // OnHoverOut is used for future proofing for liveedit
 
                     // Enable all objects that should be enabled (i.e they already were)
                     for (int i = 0; i < comp.transform.GetChildCount(); i++)
                     {
                         GameObject obj = comp.transform.GetChild(i).gameObject;
-                        obj.SetActive(data.enabled);
+                    obj.SetActive(data.show);
                     }
                 // remove collider so you can't still enter the screen if you click the right spot lol
-                comp.m_collider.enabled = data.enabled;
+                comp.m_collider.enabled = data.show;
             }
         }
 


### PR DESCRIPTION
# Features
* Entirely disable/hide entire rundown selectors through `show` property
* Rescale the text objects together through `textScale` property
* Rundown Selector colors via the `color` property
* Disable (grey out) certain rundown selectors with `enabled` property
* Allow automatic rotation of GUIX elements via in-game method to appear flattened and facing towards the camera using the `useFlatVersion` property
  * This has a minor side effect of, when updated in game, it will do a visual rotation to this position. This can also be seen when returning to the rundown selection screen.

# Refactors
* Redo how a lot of the Rundown Selector updating code goes to reduce a lot of repeated code and transform iterations
* Reduce code clutter when using custom data loader Color/Vector3s by implicitly converting them to their UnityEngine counterparts
* Change Rundown 8 specific Selector class to be subclass of `RundownSelector`
  * Made the two properties that the Rundown 8 select can't use virtual in `RundownSelector`, allowing `RundownSelector_R8` to override them to be ignored by json de/serialization, thereby maintaining the lack of them showing up in the default file or being read.